### PR TITLE
Domain registry migration fallback

### DIFF
--- a/crates/pallet-domains/src/benchmarking.rs
+++ b/crates/pallet-domains/src/benchmarking.rs
@@ -814,6 +814,7 @@ mod benchmarks {
 
         let domain_owner = DomainRegistry::<T>::get(domain_id)
             .expect("domain object must exist")
+            .current
             .owner_account_id;
         let new_allow_list = OperatorAllowList::Operators(BTreeSet::from_iter(vec![account(
             "allowed-account",

--- a/crates/pallet-domains/src/domain_registry.rs
+++ b/crates/pallet-domains/src/domain_registry.rs
@@ -329,7 +329,7 @@ pub(crate) fn do_instantiate_domain<T: Config>(
         domain_runtime_info,
         domain_instantiation_deposit,
     };
-    DomainRegistry::<T>::insert(domain_id, domain_obj);
+    DomainRegistry::<T>::set(domain_id, Some(domain_obj.into()));
 
     let next_domain_id = domain_id.checked_add(&1.into()).ok_or(Error::MaxDomainId)?;
     NextDomainId::<T>::set(next_domain_id);

--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -173,6 +173,7 @@ mod pallet {
         do_instantiate_domain, do_update_domain_allow_list, DomainConfigParams, DomainObject,
         Error as DomainRegistryError,
     };
+    use crate::migration_v2_to_v3::DomainObjectV2;
     use crate::runtime_registry::{
         do_register_runtime, do_schedule_runtime_upgrade, do_upgrade_runtimes,
         register_runtime_at_genesis, DomainRuntimeUpgradeEntry, Error as RuntimeRegistryError,
@@ -237,6 +238,7 @@ mod pallet {
     use sp_std::fmt::Debug;
     use sp_subspace_mmr::MmrProofVerifier;
     use subspace_core_primitives::{Randomness, U256};
+    use subspace_runtime_primitives::codec_primitives::DecodeFallback;
     use subspace_runtime_primitives::StorageFee;
 
     #[pallet::config]
@@ -572,7 +574,11 @@ mod pallet {
         _,
         Identity,
         DomainId,
-        DomainObject<BlockNumberFor<T>, ReceiptHashFor<T>, T::AccountId, BalanceOf<T>>,
+        // TODO: remove this fallback once the V3 migration has been applied to Taurus and Mainnet
+        DecodeFallback<
+            DomainObject<BlockNumberFor<T>, ReceiptHashFor<T>, T::AccountId, BalanceOf<T>>,
+            DomainObjectV2<BlockNumberFor<T>, ReceiptHashFor<T>, T::AccountId, BalanceOf<T>>,
+        >,
         OptionQuery,
     >;
 
@@ -2166,9 +2172,9 @@ impl<T: Config> Pallet<T> {
         let raw_genesis = into_complete_raw_genesis::<T>(
             runtime_object,
             domain_id,
-            &domain_obj.domain_runtime_info,
+            &domain_obj.current.domain_runtime_info,
             total_issuance,
-            domain_obj.domain_config.initial_balances,
+            domain_obj.current.domain_config.initial_balances,
         )
         .ok()?;
         Some((
@@ -2176,7 +2182,7 @@ impl<T: Config> Pallet<T> {
                 runtime_type,
                 raw_genesis,
             },
-            domain_obj.created_at,
+            domain_obj.current.created_at,
         ))
     }
 
@@ -2392,17 +2398,17 @@ impl<T: Config> Pallet<T> {
             BundleError::UnexpectedReceiptGap,
         );
 
-        let domain_config = DomainRegistry::<T>::get(domain_id)
+        let domain_config = &DomainRegistry::<T>::get(domain_id)
             .ok_or(BundleError::InvalidDomainId)?
             .domain_config;
 
-        Self::validate_bundle(opaque_bundle, &domain_config)?;
+        Self::validate_bundle(opaque_bundle, domain_config)?;
 
         Self::validate_eligibility(
             sealed_header.pre_hash().as_ref(),
             &sealed_header.signature,
             &sealed_header.header.proof_of_election,
-            &domain_config,
+            domain_config,
             pre_dispatch,
         )?;
 
@@ -2430,6 +2436,7 @@ impl<T: Config> Pallet<T> {
 
         let domain_config = DomainRegistry::<T>::get(domain_id)
             .ok_or(BundleError::InvalidDomainId)?
+            .current
             .domain_config;
         Self::validate_eligibility(
             sealed_singleton_receipt.pre_hash().as_ref(),
@@ -2772,7 +2779,7 @@ impl<T: Config> Pallet<T> {
     ) -> Result<Option<DomainBundleLimit>, DomainRegistryError> {
         let domain_config = match DomainRegistry::<T>::get(domain_id) {
             None => return Ok(None),
-            Some(domain_obj) => domain_obj.domain_config,
+            Some(domain_obj) => domain_obj.current.domain_config,
         };
 
         Ok(Some(DomainBundleLimit {

--- a/crates/pallet-domains/src/migration_v2_to_v3.rs
+++ b/crates/pallet-domains/src/migration_v2_to_v3.rs
@@ -25,45 +25,24 @@ impl<T: Config> UncheckedOnRuntimeUpgrade for VersionUncheckedMigrateV2ToV3<T> {
 }
 
 mod domain_registry_structure_migration {
-    use crate::domain_registry::{DomainConfig as DomainConfigV3, DomainObject as DomainObjectV3};
-    use crate::pallet::DomainRegistry as DomainRegistryV3;
-    use crate::runtime_registry::DomainRuntimeInfo as DomainRuntimeInfoV3;
+    // Types that have changed are imported or declared with a V2/V3 suffix.
+    // Types that haven't changed are imported or declared without a suffix.
+    pub(super) use crate::domain_registry::{DomainConfig, DomainObject as DomainObjectV3};
+    pub(super) use crate::pallet::DomainRegistry as DomainRegistryV3;
+    pub(super) use crate::runtime_registry::DomainRuntimeInfo as DomainRuntimeInfoV3;
     use crate::{BalanceOf, BlockNumberFor, Config, Pallet, ReceiptHashFor};
     use codec::{Decode, Encode};
-    use domain_runtime_primitives::{EVMChainId, MultiAccountId};
+    use domain_runtime_primitives::EVMChainId;
     use frame_support::pallet_prelude::{OptionQuery, TypeInfo, Weight};
     use frame_support::{storage_alias, Identity};
-    use scale_info::prelude::string::String;
     use sp_core::Get;
-    use sp_domains::{
-        AutoIdDomainRuntimeConfig,
+    pub(super) use sp_domains::{
+        AutoIdDomainRuntimeConfig as AutoIdDomainRuntimeConfigV3,
         DomainId,
         // changed in V3, but we use Into to convert to it
         // DomainRuntimeConfig as DomainRuntimeConfigV3,
-        EvmDomainRuntimeConfig,
-        OperatorAllowList,
-        RuntimeId,
+        EvmDomainRuntimeConfig as EvmDomainRuntimeConfigV3,
     };
-    use sp_runtime::Vec;
-
-    #[derive(TypeInfo, Debug, Encode, Decode, Clone, PartialEq, Eq)]
-    pub struct DomainConfigV2<AccountId: Ord, Balance> {
-        /// A user defined name for this domain, should be a human-readable UTF-8 encoded string.
-        pub domain_name: String,
-        /// A pointer to the `RuntimeRegistry` entry for this domain.
-        pub runtime_id: RuntimeId,
-        /// The max bundle size for this domain, may not exceed the system-wide `MaxDomainBlockSize` limit.
-        pub max_bundle_size: u32,
-        /// The max bundle weight for this domain, may not exceed the system-wide `MaxDomainBlockWeight` limit.
-        pub max_bundle_weight: Weight,
-        /// The probability of successful bundle in a slot (active slots coefficient). This defines the
-        /// expected bundle production rate, must be `> 0` and `≤ 1`.
-        pub bundle_slot_probability: (u64, u64),
-        /// Allowed operators to operate for this domain.
-        pub operator_allow_list: OperatorAllowList<AccountId>,
-        // Initial balances for Domain.
-        pub initial_balances: Vec<(MultiAccountId, Balance)>,
-    }
 
     /// Domain runtime specific information to create domain raw genesis.
     #[derive(TypeInfo, Debug, Encode, Decode, Clone, PartialEq, Eq, Copy)]
@@ -82,7 +61,7 @@ mod domain_registry_structure_migration {
         /// The hash of the genesis execution receipt for this domain.
         pub genesis_receipt_hash: ReceiptHash,
         /// The domain config.
-        pub domain_config: DomainConfigV2<AccountId, Balance>,
+        pub domain_config: DomainConfig<AccountId, Balance>,
         /// Domain runtime specific information.
         pub domain_runtime_info: DomainRuntimeInfoV2,
         /// The amount of balance hold on the domain owner account
@@ -112,18 +91,18 @@ mod domain_registry_structure_migration {
         >(|domain_object_v2| {
             domain_count += 1;
 
-            let domain_runtime_info = match domain_object_v2.domain_runtime_info {
+            let domain_runtime_info_v3 = match domain_object_v2.domain_runtime_info {
                 DomainRuntimeInfoV2::EVM { chain_id } => {
                     DomainRuntimeInfoV3::Evm {
                         chain_id,
                         // Added in V3
-                        domain_runtime_config: EvmDomainRuntimeConfig::default(),
+                        domain_runtime_config: EvmDomainRuntimeConfigV3::default(),
                     }
                 }
                 DomainRuntimeInfoV2::AutoId => {
                     DomainRuntimeInfoV3::AutoId {
                         // Added in V3
-                        domain_runtime_config: AutoIdDomainRuntimeConfig::default(),
+                        domain_runtime_config: AutoIdDomainRuntimeConfigV3::default(),
                     }
                 }
             };
@@ -132,17 +111,9 @@ mod domain_registry_structure_migration {
                 owner_account_id: domain_object_v2.owner_account_id,
                 created_at: domain_object_v2.created_at,
                 genesis_receipt_hash: domain_object_v2.genesis_receipt_hash,
-                domain_config: DomainConfigV3 {
-                    domain_name: domain_object_v2.domain_config.domain_name,
-                    runtime_id: domain_object_v2.domain_config.runtime_id,
-                    max_bundle_size: domain_object_v2.domain_config.max_bundle_size,
-                    max_bundle_weight: domain_object_v2.domain_config.max_bundle_weight,
-                    bundle_slot_probability: domain_object_v2.domain_config.bundle_slot_probability,
-                    operator_allow_list: domain_object_v2.domain_config.operator_allow_list,
-                    initial_balances: domain_object_v2.domain_config.initial_balances,
-                },
+                domain_config: domain_object_v2.domain_config,
                 // Modified in V3
-                domain_runtime_info,
+                domain_runtime_info: domain_runtime_info_v3,
                 domain_instantiation_deposit: domain_object_v2.domain_instantiation_deposit,
             })
         });
@@ -155,35 +126,32 @@ mod domain_registry_structure_migration {
 #[cfg(test)]
 mod tests {
     use super::domain_registry_structure_migration::{
-        migrate_domain_registry_structure, DomainConfigV2, DomainObjectV2, DomainRegistry,
-        DomainRuntimeInfoV2,
+        migrate_domain_registry_structure, AutoIdDomainRuntimeConfigV3, DomainConfig, DomainId,
+        DomainObjectV2, DomainObjectV3, DomainRegistry, DomainRegistryV3, DomainRuntimeInfoV2,
+        DomainRuntimeInfoV3, EvmDomainRuntimeConfigV3,
     };
-    use crate::domain_registry::{DomainConfig as DomainConfigV3, DomainObject as DomainObjectV3};
-    use crate::pallet::DomainRegistry as DomainRegistryV3;
-    use crate::runtime_registry::DomainRuntimeInfo as DomainRuntimeInfoV3;
     use crate::tests::{new_test_ext, Test};
-    use sp_domains::{
-        AutoIdDomainRuntimeConfig, DomainId, EvmDomainRuntimeConfig, EvmType, OperatorAllowList,
-    };
+    use sp_domains::{EvmType as EvmTypeV3, OperatorAllowList};
 
     #[test]
     fn test_domain_registry_structure_migration_evm() {
         let mut ext = new_test_ext();
         let domain_id: DomainId = 0.into();
         let chain_id = 8u32.into();
+        let domain_config = DomainConfig {
+            domain_name: "test-evm-migrate".to_string(),
+            runtime_id: 3u32,
+            max_bundle_size: 4,
+            max_bundle_weight: 5.into(),
+            bundle_slot_probability: (6, 7),
+            operator_allow_list: OperatorAllowList::Anyone,
+            initial_balances: vec![],
+        };
         let domain = DomainObjectV2 {
             owner_account_id: 1u32.into(),
             created_at: 2u32.into(),
             genesis_receipt_hash: Default::default(),
-            domain_config: DomainConfigV2 {
-                domain_name: "test-evm-migrate".to_string(),
-                runtime_id: 3u32,
-                max_bundle_size: 4,
-                max_bundle_weight: 5.into(),
-                bundle_slot_probability: (6, 7),
-                operator_allow_list: OperatorAllowList::Anyone,
-                initial_balances: vec![],
-            },
+            domain_config: domain_config.clone(),
             domain_runtime_info: DomainRuntimeInfoV2::EVM { chain_id },
             domain_instantiation_deposit: 9u32.into(),
         };
@@ -204,20 +172,12 @@ mod tests {
                     owner_account_id: domain.owner_account_id,
                     created_at: domain.created_at,
                     genesis_receipt_hash: domain.genesis_receipt_hash,
-                    domain_config: DomainConfigV3 {
-                        domain_name: domain.domain_config.domain_name,
-                        runtime_id: domain.domain_config.runtime_id,
-                        max_bundle_size: domain.domain_config.max_bundle_size,
-                        max_bundle_weight: domain.domain_config.max_bundle_weight,
-                        bundle_slot_probability: domain.domain_config.bundle_slot_probability,
-                        operator_allow_list: domain.domain_config.operator_allow_list,
-                        initial_balances: domain.domain_config.initial_balances,
-                    },
+                    domain_config,
                     domain_runtime_info: DomainRuntimeInfoV3::Evm {
                         chain_id,
-                        domain_runtime_config: EvmDomainRuntimeConfig {
+                        domain_runtime_config: EvmDomainRuntimeConfigV3 {
                             // All current EVM domains are public EVMs
-                            evm_type: EvmType::Public
+                            evm_type: EvmTypeV3::Public
                         },
                     },
                     domain_instantiation_deposit: domain.domain_instantiation_deposit,
@@ -230,19 +190,20 @@ mod tests {
     fn test_domain_registry_structure_migration_auto_id() {
         let mut ext = new_test_ext();
         let domain_id: DomainId = 10.into();
+        let domain_config = DomainConfig {
+            domain_name: "test-auto-id-migrate".to_string(),
+            runtime_id: 13u32,
+            max_bundle_size: 14,
+            max_bundle_weight: 15.into(),
+            bundle_slot_probability: (16, 17),
+            operator_allow_list: OperatorAllowList::Anyone,
+            initial_balances: vec![],
+        };
         let domain = DomainObjectV2 {
             owner_account_id: 11u32.into(),
             created_at: 12u32.into(),
             genesis_receipt_hash: Default::default(),
-            domain_config: DomainConfigV2 {
-                domain_name: "test-auto-id-migrate".to_string(),
-                runtime_id: 13u32,
-                max_bundle_size: 14,
-                max_bundle_weight: 15.into(),
-                bundle_slot_probability: (16, 17),
-                operator_allow_list: OperatorAllowList::Anyone,
-                initial_balances: vec![],
-            },
+            domain_config: domain_config.clone(),
             domain_runtime_info: DomainRuntimeInfoV2::AutoId,
             domain_instantiation_deposit: 19u32.into(),
         };
@@ -263,18 +224,10 @@ mod tests {
                     owner_account_id: domain.owner_account_id,
                     created_at: domain.created_at,
                     genesis_receipt_hash: domain.genesis_receipt_hash,
-                    domain_config: DomainConfigV3 {
-                        domain_name: domain.domain_config.domain_name,
-                        runtime_id: domain.domain_config.runtime_id,
-                        max_bundle_size: domain.domain_config.max_bundle_size,
-                        max_bundle_weight: domain.domain_config.max_bundle_weight,
-                        bundle_slot_probability: domain.domain_config.bundle_slot_probability,
-                        operator_allow_list: domain.domain_config.operator_allow_list,
-                        initial_balances: domain.domain_config.initial_balances,
-                    },
+                    domain_config,
                     domain_runtime_info: DomainRuntimeInfoV3::AutoId {
                         // There are no AutoId-specific config fields at this time
-                        domain_runtime_config: AutoIdDomainRuntimeConfig {}
+                        domain_runtime_config: AutoIdDomainRuntimeConfigV3 {}
                     },
                     domain_instantiation_deposit: domain.domain_instantiation_deposit,
                 })

--- a/crates/pallet-domains/src/migration_v2_to_v3.rs
+++ b/crates/pallet-domains/src/migration_v2_to_v3.rs
@@ -4,10 +4,25 @@
 //! If we add EVM or AutoId domains to Mainnet, also deploy it there.
 //! (If there are no EVM or AutoId domains, this migration does nothing, so it's safe to run.)
 
+// Types that have changed are imported or declared with a V2/V3 suffix.
+// Types that haven't changed are imported or declared without a suffix.
+use crate::domain_registry::{DomainConfig, DomainObject as DomainObjectV3};
+use crate::pallet::DomainRegistry as DomainRegistryV3;
+use crate::runtime_registry::DomainRuntimeInfo as DomainRuntimeInfoV3;
 use crate::{Config, Pallet};
+use codec::{Decode, Encode};
+use domain_runtime_primitives::EVMChainId;
 use frame_support::migrations::VersionedMigration;
+use frame_support::pallet_prelude::TypeInfo;
 use frame_support::traits::UncheckedOnRuntimeUpgrade;
 use frame_support::weights::Weight;
+use sp_domains::{
+    AutoIdDomainRuntimeConfig as AutoIdDomainRuntimeConfigV3,
+    // changed in V3, but we use Into to convert to it
+    // DomainRuntimeConfig as DomainRuntimeConfigV3,
+    EvmDomainRuntimeConfig as EvmDomainRuntimeConfigV3,
+};
+use subspace_runtime_primitives::codec_primitives::DecodeFallback;
 
 pub type VersionCheckedMigrateDomainsV2ToV3<T> = VersionedMigration<
     2,
@@ -24,63 +39,88 @@ impl<T: Config> UncheckedOnRuntimeUpgrade for VersionUncheckedMigrateV2ToV3<T> {
     }
 }
 
+/// Domain runtime specific information to create domain raw genesis.
+#[derive(TypeInfo, Debug, Encode, Decode, Clone, PartialEq, Eq, Copy)]
+#[allow(clippy::upper_case_acronyms)]
+pub enum DomainRuntimeInfoV2 {
+    EVM { chain_id: EVMChainId },
+    AutoId,
+}
+
+#[derive(TypeInfo, Debug, Encode, Decode, Clone, PartialEq, Eq)]
+pub struct DomainObjectV2<Number, ReceiptHash, AccountId: Ord, Balance> {
+    /// The address of the domain creator, used to validate updating the domain config.
+    pub owner_account_id: AccountId,
+    /// The consensus chain block number when the domain first instantiated.
+    pub created_at: Number,
+    /// The hash of the genesis execution receipt for this domain.
+    pub genesis_receipt_hash: ReceiptHash,
+    /// The domain config.
+    pub domain_config: DomainConfig<AccountId, Balance>,
+    /// Domain runtime specific information.
+    pub domain_runtime_info: DomainRuntimeInfoV2,
+    /// The amount of balance hold on the domain owner account
+    pub domain_instantiation_deposit: Balance,
+}
+
+impl<T, U, V: Ord, W> From<DomainObjectV2<T, U, V, W>> for DomainObjectV3<T, U, V, W> {
+    fn from(domain_object_v2: DomainObjectV2<T, U, V, W>) -> Self {
+        let DomainObjectV2 {
+            owner_account_id,
+            created_at,
+            genesis_receipt_hash,
+            domain_config,
+            domain_runtime_info: domain_runtime_info_v2,
+            domain_instantiation_deposit,
+        } = domain_object_v2;
+
+        DomainObjectV3 {
+            owner_account_id,
+            created_at,
+            genesis_receipt_hash,
+            domain_config,
+            domain_runtime_info: domain_runtime_info_v2.into(),
+            domain_instantiation_deposit,
+        }
+    }
+}
+
+impl From<DomainRuntimeInfoV2> for DomainRuntimeInfoV3 {
+    fn from(domain_runtime_info_v2: DomainRuntimeInfoV2) -> Self {
+        match domain_runtime_info_v2 {
+            DomainRuntimeInfoV2::EVM { chain_id } => DomainRuntimeInfoV3::Evm {
+                chain_id,
+                // Added in V3
+                domain_runtime_config: EvmDomainRuntimeConfigV3::default(),
+            },
+            DomainRuntimeInfoV2::AutoId => DomainRuntimeInfoV3::AutoId {
+                // Added in V3
+                domain_runtime_config: AutoIdDomainRuntimeConfigV3::default(),
+            },
+        }
+    }
+}
+
+// These impls are needed because DecodeFallback can't do it generically due to the orphan trait rules.
+impl<T, U, V: Ord, W>
+    PartialEq<DecodeFallback<DomainObjectV3<T, U, V, W>, DomainObjectV2<T, U, V, W>>>
+    for DomainObjectV3<T, U, V, W>
+where
+    DomainObjectV3<T, U, V, W>: PartialEq,
+{
+    fn eq(
+        &self,
+        other: &DecodeFallback<DomainObjectV3<T, U, V, W>, DomainObjectV2<T, U, V, W>>,
+    ) -> bool {
+        self == &other.current
+    }
+}
+
 mod domain_registry_structure_migration {
-    // Types that have changed are imported or declared with a V2/V3 suffix.
-    // Types that haven't changed are imported or declared without a suffix.
-    pub(super) use crate::domain_registry::{DomainConfig, DomainObject as DomainObjectV3};
-    pub(super) use crate::pallet::DomainRegistry as DomainRegistryV3;
-    pub(super) use crate::runtime_registry::DomainRuntimeInfo as DomainRuntimeInfoV3;
-    use crate::{BalanceOf, BlockNumberFor, Config, Pallet, ReceiptHashFor};
-    use codec::{Decode, Encode};
-    use domain_runtime_primitives::EVMChainId;
-    use frame_support::pallet_prelude::{OptionQuery, TypeInfo, Weight};
-    use frame_support::{storage_alias, Identity};
+    use super::{DomainObjectV2, DomainObjectV3, DomainRegistryV3};
+    use crate::{BalanceOf, BlockNumberFor, Config, ReceiptHashFor};
+    use frame_support::pallet_prelude::Weight;
     use sp_core::Get;
-    pub(super) use sp_domains::{
-        AutoIdDomainRuntimeConfig as AutoIdDomainRuntimeConfigV3,
-        DomainId,
-        // changed in V3, but we use Into to convert to it
-        // DomainRuntimeConfig as DomainRuntimeConfigV3,
-        EvmDomainRuntimeConfig as EvmDomainRuntimeConfigV3,
-    };
-
-    /// Domain runtime specific information to create domain raw genesis.
-    #[derive(TypeInfo, Debug, Encode, Decode, Clone, PartialEq, Eq, Copy)]
-    #[allow(clippy::upper_case_acronyms)]
-    pub enum DomainRuntimeInfoV2 {
-        EVM { chain_id: EVMChainId },
-        AutoId,
-    }
-
-    #[derive(TypeInfo, Debug, Encode, Decode, Clone, PartialEq, Eq)]
-    pub struct DomainObjectV2<Number, ReceiptHash, AccountId: Ord, Balance> {
-        /// The address of the domain creator, used to validate updating the domain config.
-        pub owner_account_id: AccountId,
-        /// The consensus chain block number when the domain first instantiated.
-        pub created_at: Number,
-        /// The hash of the genesis execution receipt for this domain.
-        pub genesis_receipt_hash: ReceiptHash,
-        /// The domain config.
-        pub domain_config: DomainConfig<AccountId, Balance>,
-        /// Domain runtime specific information.
-        pub domain_runtime_info: DomainRuntimeInfoV2,
-        /// The amount of balance hold on the domain owner account
-        pub domain_instantiation_deposit: Balance,
-    }
-
-    #[storage_alias]
-    pub(super) type DomainRegistry<T: Config> = StorageMap<
-        Pallet<T>,
-        Identity,
-        DomainId,
-        DomainObjectV2<
-            BlockNumberFor<T>,
-            ReceiptHashFor<T>,
-            <T as frame_system::Config>::AccountId,
-            BalanceOf<T>,
-        >,
-        OptionQuery,
-    >;
 
     pub(super) fn migrate_domain_registry_structure<T: Config>() -> Weight {
         let mut domain_count = 0;
@@ -91,31 +131,7 @@ mod domain_registry_structure_migration {
         >(|domain_object_v2| {
             domain_count += 1;
 
-            let domain_runtime_info_v3 = match domain_object_v2.domain_runtime_info {
-                DomainRuntimeInfoV2::EVM { chain_id } => {
-                    DomainRuntimeInfoV3::Evm {
-                        chain_id,
-                        // Added in V3
-                        domain_runtime_config: EvmDomainRuntimeConfigV3::default(),
-                    }
-                }
-                DomainRuntimeInfoV2::AutoId => {
-                    DomainRuntimeInfoV3::AutoId {
-                        // Added in V3
-                        domain_runtime_config: AutoIdDomainRuntimeConfigV3::default(),
-                    }
-                }
-            };
-
-            Some(DomainObjectV3 {
-                owner_account_id: domain_object_v2.owner_account_id,
-                created_at: domain_object_v2.created_at,
-                genesis_receipt_hash: domain_object_v2.genesis_receipt_hash,
-                domain_config: domain_object_v2.domain_config,
-                // Modified in V3
-                domain_runtime_info: domain_runtime_info_v3,
-                domain_instantiation_deposit: domain_object_v2.domain_instantiation_deposit,
-            })
+            Some(DomainObjectV3::from(domain_object_v2).into())
         });
 
         // 1 read and 1 write per domain
@@ -125,13 +141,56 @@ mod domain_registry_structure_migration {
 
 #[cfg(test)]
 mod tests {
-    use super::domain_registry_structure_migration::{
-        migrate_domain_registry_structure, AutoIdDomainRuntimeConfigV3, DomainConfig, DomainId,
-        DomainObjectV2, DomainObjectV3, DomainRegistry, DomainRegistryV3, DomainRuntimeInfoV2,
-        DomainRuntimeInfoV3, EvmDomainRuntimeConfigV3,
-    };
+    use super::domain_registry_structure_migration::*;
+    use super::*;
     use crate::tests::{new_test_ext, Test};
-    use sp_domains::{EvmType as EvmTypeV3, OperatorAllowList};
+    use registry_v2::DomainRegistry as DomainRegistryV2;
+    use registry_v3_only::DomainRegistry as DomainRegistryV3Only;
+    use sp_domains::{DomainId, EvmType as EvmTypeV3, OperatorAllowList};
+
+    mod registry_v2 {
+        use super::*;
+        use crate::{BalanceOf, Config, Pallet, ReceiptHashFor};
+        use frame_support::pallet_prelude::OptionQuery;
+        use frame_support::{storage_alias, Identity};
+        use frame_system::pallet_prelude::BlockNumberFor;
+
+        #[storage_alias]
+        pub(super) type DomainRegistry<T: Config> = StorageMap<
+            Pallet<T>,
+            Identity,
+            DomainId,
+            DomainObjectV2<
+                BlockNumberFor<T>,
+                ReceiptHashFor<T>,
+                <T as frame_system::Config>::AccountId,
+                BalanceOf<T>,
+            >,
+            OptionQuery,
+        >;
+    }
+
+    mod registry_v3_only {
+        use super::*;
+        use crate::{BalanceOf, Config, Pallet, ReceiptHashFor};
+        use frame_support::pallet_prelude::OptionQuery;
+        use frame_support::{storage_alias, Identity};
+        use frame_system::pallet_prelude::BlockNumberFor;
+
+        #[storage_alias]
+        pub(super) type DomainRegistry<T: Config> = StorageMap<
+            Pallet<T>,
+            Identity,
+            DomainId,
+            DomainObjectV3<
+                BlockNumberFor<T>,
+                ReceiptHashFor<T>,
+                <T as frame_system::Config>::AccountId,
+                BalanceOf<T>,
+            >,
+            OptionQuery,
+        >;
+    }
 
     #[test]
     fn test_domain_registry_structure_migration_evm() {
@@ -155,10 +214,27 @@ mod tests {
             domain_runtime_info: DomainRuntimeInfoV2::EVM { chain_id },
             domain_instantiation_deposit: 9u32.into(),
         };
+        let expected_migration = DomainObjectV3 {
+            owner_account_id: domain.owner_account_id,
+            created_at: domain.created_at,
+            genesis_receipt_hash: domain.genesis_receipt_hash,
+            domain_config: domain_config.clone(),
+            domain_runtime_info: DomainRuntimeInfoV3::Evm {
+                chain_id,
+                domain_runtime_config: EvmDomainRuntimeConfigV3 {
+                    // All current EVM domains are public EVMs
+                    evm_type: EvmTypeV3::Public,
+                },
+            },
+            domain_instantiation_deposit: domain.domain_instantiation_deposit,
+        };
 
-        ext.execute_with(|| DomainRegistry::<Test>::set(domain_id, Some(domain.clone())));
+        ext.execute_with(|| DomainRegistryV2::<Test>::set(domain_id, Some(domain.clone())));
 
         ext.commit_all().unwrap();
+
+        let fallback_outcome = ext.execute_with(|| DomainRegistryV3::<Test>::get(domain_id));
+        assert_eq!(fallback_outcome.unwrap(), expected_migration);
 
         ext.execute_with(|| {
             let weights = migrate_domain_registry_structure::<Test>();
@@ -167,21 +243,12 @@ mod tests {
                 <Test as frame_system::Config>::DbWeight::get().reads_writes(1, 1),
             );
             assert_eq!(
-                DomainRegistryV3::<Test>::get(domain_id),
-                Some(DomainObjectV3 {
-                    owner_account_id: domain.owner_account_id,
-                    created_at: domain.created_at,
-                    genesis_receipt_hash: domain.genesis_receipt_hash,
-                    domain_config,
-                    domain_runtime_info: DomainRuntimeInfoV3::Evm {
-                        chain_id,
-                        domain_runtime_config: EvmDomainRuntimeConfigV3 {
-                            // All current EVM domains are public EVMs
-                            evm_type: EvmTypeV3::Public
-                        },
-                    },
-                    domain_instantiation_deposit: domain.domain_instantiation_deposit,
-                })
+                DomainRegistryV3Only::<Test>::get(domain_id),
+                Some(expected_migration.clone()),
+            );
+            assert_eq!(
+                DomainRegistryV3::<Test>::get(domain_id).unwrap(),
+                expected_migration,
             );
         });
     }
@@ -207,10 +274,24 @@ mod tests {
             domain_runtime_info: DomainRuntimeInfoV2::AutoId,
             domain_instantiation_deposit: 19u32.into(),
         };
+        let expected_migration = DomainObjectV3 {
+            owner_account_id: domain.owner_account_id,
+            created_at: domain.created_at,
+            genesis_receipt_hash: domain.genesis_receipt_hash,
+            domain_config,
+            domain_runtime_info: DomainRuntimeInfoV3::AutoId {
+                // There are no AutoId-specific config fields at this time
+                domain_runtime_config: AutoIdDomainRuntimeConfigV3 {},
+            },
+            domain_instantiation_deposit: domain.domain_instantiation_deposit,
+        };
 
-        ext.execute_with(|| DomainRegistry::<Test>::set(domain_id, Some(domain.clone())));
+        ext.execute_with(|| DomainRegistryV2::<Test>::set(domain_id, Some(domain.clone())));
 
         ext.commit_all().unwrap();
+
+        let fallback_outcome = ext.execute_with(|| DomainRegistryV3::<Test>::get(domain_id));
+        assert_eq!(fallback_outcome.unwrap(), expected_migration);
 
         ext.execute_with(|| {
             let weights = migrate_domain_registry_structure::<Test>();
@@ -219,18 +300,12 @@ mod tests {
                 <Test as frame_system::Config>::DbWeight::get().reads_writes(1, 1),
             );
             assert_eq!(
-                DomainRegistryV3::<Test>::get(domain_id),
-                Some(DomainObjectV3 {
-                    owner_account_id: domain.owner_account_id,
-                    created_at: domain.created_at,
-                    genesis_receipt_hash: domain.genesis_receipt_hash,
-                    domain_config,
-                    domain_runtime_info: DomainRuntimeInfoV3::AutoId {
-                        // There are no AutoId-specific config fields at this time
-                        domain_runtime_config: AutoIdDomainRuntimeConfigV3 {}
-                    },
-                    domain_instantiation_deposit: domain.domain_instantiation_deposit,
-                })
+                DomainRegistryV3Only::<Test>::get(domain_id),
+                Some(expected_migration.clone()),
+            );
+            assert_eq!(
+                DomainRegistryV3::<Test>::get(domain_id).unwrap(),
+                expected_migration,
             );
         });
     }

--- a/crates/pallet-domains/src/staking.rs
+++ b/crates/pallet-domains/src/staking.rs
@@ -1465,7 +1465,7 @@ pub(crate) mod tests {
                 domain_instantiation_deposit: Default::default(),
             };
 
-            DomainRegistry::<Test>::insert(domain_id, domain_obj);
+            DomainRegistry::<Test>::set(domain_id, Some(domain_obj.into()));
         }
 
         if !DomainStakingSummary::<Test>::contains_key(domain_id) {
@@ -1828,7 +1828,7 @@ pub(crate) mod tests {
                 domain_instantiation_deposit: Default::default(),
             };
 
-            DomainRegistry::<Test>::insert(new_domain_id, domain_obj);
+            DomainRegistry::<Test>::set(new_domain_id, Some(domain_obj.into()));
             DomainStakingSummary::<Test>::insert(
                 new_domain_id,
                 StakingSummary {

--- a/crates/pallet-domains/src/tests.rs
+++ b/crates/pallet-domains/src/tests.rs
@@ -644,7 +644,7 @@ fn test_bundle_format_verification() {
             domain_runtime_info: Default::default(),
             domain_instantiation_deposit: Default::default(),
         };
-        DomainRegistry::<Test>::insert(domain_id, domain_obj);
+        DomainRegistry::<Test>::set(domain_id, Some(domain_obj.into()));
 
         let mut valid_bundle = create_dummy_bundle(DOMAIN_ID, 0, System::parent_hash());
         valid_bundle.extrinsics.push(opaque_extrinsic(1, 1));

--- a/crates/subspace-runtime-primitives/src/codec_primitives.rs
+++ b/crates/subspace-runtime-primitives/src/codec_primitives.rs
@@ -1,0 +1,141 @@
+//! SCALE codec encoding and decoding primitives.
+
+use codec::{Decode, Encode, EncodeLike, Error, Input, Output};
+use scale_info::prelude::marker::PhantomData;
+use scale_info::prelude::ops::{Deref, DerefMut};
+use scale_info::prelude::vec::Vec;
+use scale_info::TypeInfo;
+
+/// A type that decodes from either `Current` or `Fallback`, but always encodes to `Current`.
+/// Useful for types that are decoded before or during storage migrations.
+///
+/// If decoding both types fails, returns the error from decoding `Current`.
+#[derive(Clone, Debug, PartialEq, Eq, TypeInfo)]
+pub struct DecodeFallback<Current, Fallback> {
+    /// The decoded value, possibly converted from `Fallback`.
+    pub current: Current,
+    /// A marker to bind the `Fallback` generic to this struct.
+    _phantom: PhantomData<Fallback>,
+}
+
+impl<Current, Fallback> EncodeLike<DecodeFallback<Current, Fallback>>
+    for DecodeFallback<Current, Fallback>
+where
+    Self: Encode,
+{
+}
+
+impl<Current, Fallback> Deref for DecodeFallback<Current, Fallback> {
+    type Target = Current;
+
+    fn deref(&self) -> &Self::Target {
+        &self.current
+    }
+}
+
+impl<Current, Fallback> DerefMut for DecodeFallback<Current, Fallback> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.current
+    }
+}
+
+// Unfortunately we can't implement the comparison the other way generically due to orphan rules.
+impl<Current, Fallback> PartialEq<Current> for DecodeFallback<Current, Fallback>
+where
+    Current: PartialEq,
+{
+    fn eq(&self, other: &Current) -> bool {
+        &self.current == other
+    }
+}
+
+impl<Current, Fallback> From<Current> for DecodeFallback<Current, Fallback> {
+    fn from(current: Current) -> Self {
+        Self {
+            current,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+// Always encodes to Current
+impl<Current, Fallback> Encode for DecodeFallback<Current, Fallback>
+where
+    Current: Encode,
+{
+    fn size_hint(&self) -> usize {
+        self.current().size_hint()
+    }
+
+    fn encode_to<T: Output + ?Sized>(&self, dest: &mut T) {
+        self.current().encode_to(dest)
+    }
+
+    fn encode(&self) -> Vec<u8> {
+        self.current().encode()
+    }
+
+    fn using_encoded<R, F: FnOnce(&[u8]) -> R>(&self, f: F) -> R {
+        self.current().using_encoded(f)
+    }
+
+    fn encoded_size(&self) -> usize {
+        self.current().encoded_size()
+    }
+}
+
+// Try decoding as Current, then if that fails, decode as Fallback
+impl<Current, Fallback> Decode for DecodeFallback<Current, Fallback>
+where
+    Current: Decode,
+    Fallback: Decode + Into<Current>,
+{
+    fn decode<I: Input>(input: &mut I) -> Result<Self, Error> {
+        match Current::decode(input) {
+            Ok(current) => Ok(Self {
+                current,
+                _phantom: PhantomData,
+            }),
+            Err(current_error) => {
+                if let Ok(fallback) = Fallback::decode(input) {
+                    Ok(Self {
+                        current: fallback.into(),
+                        _phantom: PhantomData,
+                    })
+                } else {
+                    Err(current_error)
+                }
+            }
+        }
+    }
+
+    fn encoded_fixed_size() -> Option<usize> {
+        // All values only have a fixed size if the fixed sizes of the current and fallback types
+        // are the same.
+        if Current::encoded_fixed_size() == Fallback::encoded_fixed_size() {
+            Current::encoded_fixed_size()
+        } else {
+            None
+        }
+    }
+}
+
+impl<Current, Fallback> DecodeFallback<Current, Fallback> {
+    /// Returns the `Current` value.
+    #[inline]
+    pub fn current(&self) -> &Current {
+        &self.current
+    }
+
+    /// Returns a mutable reference to the `Current` value.
+    #[inline]
+    pub fn current_mut(&mut self) -> &mut Current {
+        &mut self.current
+    }
+
+    /// Extracts the `Current` value.
+    #[inline]
+    pub fn into_current(self) -> Current {
+        self.current
+    }
+}

--- a/crates/subspace-runtime-primitives/src/lib.rs
+++ b/crates/subspace-runtime-primitives/src/lib.rs
@@ -2,6 +2,7 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
+pub mod codec_primitives;
 pub mod extensions;
 pub mod utility;
 

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -1039,8 +1039,9 @@ pub type Executive = frame_executive::Executive<
     (
         // TODO: remove once migration has been deployed to Taurus and Mainnet
         pallet_messenger::migrations::VersionCheckedMigrateDomainsV0ToV1<Runtime>,
+        // TODO: run in the next upgrade, after a runtime with a DecodeFallback to the previous domain registry type has been fully deployed
         // TODO: remove once migration has been deployed to Taurus
-        pallet_domains::migration_v2_to_v3::VersionCheckedMigrateDomainsV2ToV3<Runtime>,
+        //pallet_domains::migration_v2_to_v3::VersionCheckedMigrateDomainsV2ToV3<Runtime>,
     ),
 >;
 

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -122,7 +122,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     impl_name: Cow::Borrowed("subspace"),
     authoring_version: 0,
     // The spec version can be different on Taurus and Mainnet
-    spec_version: 2,
+    spec_version: 3,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 0,

--- a/domains/client/block-preprocessor/src/inherents.rs
+++ b/domains/client/block-preprocessor/src/inherents.rs
@@ -73,9 +73,15 @@ where
 
     let runtime_id = runtime_api
         .runtime_id(consensus_block_hash, domain_id)?
-        .ok_or(sp_blockchain::Error::Application(Box::from(format!(
-            "No RuntimeId found for {domain_id:?}"
-        ))))?;
+        .ok_or_else(|| {
+            sp_blockchain::Error::Application(Box::from(format!(
+                "No RuntimeId found for {domain_id:?} in {}\n\
+                Backtrace:\n\
+                {:?}",
+                std::any::type_name_of_val(&is_runtime_upgraded::<CClient, CBlock, Block>),
+                std::backtrace::Backtrace::force_capture(),
+            )))
+        })?;
 
     // The runtime_upgrades() API is only present in API versions 2 and later. On earlier versions,
     // we need to call legacy code.

--- a/domains/client/domain-operator/src/fraud_proof.rs
+++ b/domains/client/domain-operator/src/fraud_proof.rs
@@ -446,9 +446,15 @@ where
             .consensus_client
             .runtime_api()
             .runtime_id(at, domain_id)?
-            .ok_or(sp_blockchain::Error::Application(Box::from(format!(
-                "No RuntimeId found for {domain_id:?}"
-            ))))?;
+            .ok_or_else(|| {
+                sp_blockchain::Error::Application(Box::from(format!(
+                    "No RuntimeId found for {domain_id:?} in {}\n\
+                    Backtrace:\n\
+                    {:?}",
+                    std::any::type_name_of_val(&Self::is_domain_runtime_upgraded_at),
+                    std::backtrace::Backtrace::force_capture(),
+                )))
+            })?;
         // This API is only present in API versions 2 and later, but it is safe to call
         // unconditionally, because:
         // - on Mainnet, there are no domains yet, and

--- a/domains/runtime/evm/src/lib.rs
+++ b/domains/runtime/evm/src/lib.rs
@@ -298,7 +298,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     impl_name: Cow::Borrowed("subspace-evm-domain"),
     authoring_version: 0,
     // The spec version can be different on Taurus and Mainnet
-    spec_version: 0,
+    spec_version: 1,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
This PR is one way to do fallback decoding during a domain registry migration.

The most important part is the fallback code, the rest of the code is here for context (or if someone wants to try testing it themselves).